### PR TITLE
Small bug fix for SSE

### DIFF
--- a/simdsampling.cpp
+++ b/simdsampling.cpp
@@ -470,7 +470,6 @@ uint64_t double_simd_sampling_fmt(const double *weights, size_t n, uint64_t seed
 #elif __SSE2__
     constexpr size_t nperel = sizeof(__m128d) / sizeof(double);
     const size_t e = n / nperel;
-    constexpr double LSS_DOUBLE_PDMUL = 1. / (1ull<<52);
     double maxv = -std::numeric_limits<double>::max();
 #ifdef __AVX__
     __m128d vmaxv = _mm_set1_pd(maxv);


### PR DESCRIPTION
For SSE2, there was a leftover static const constant which was replaced with a macro, which caused a compilation error. This is a simple fix by removing the offending line.